### PR TITLE
Added the ability to override mission editor callsigns with a table f…

### DIFF
--- a/src/200 - HoundUtils.lua
+++ b/src/200 - HoundUtils.lua
@@ -389,7 +389,21 @@ do
                     callsign = callsign .. " " .. num
                 end
             end
+            if HOUND.Utils.customFormationCallsignOverrides and type(HOUND.Utils.customFormationCallsignOverrides) == 'table' then
+                for vanillaCallsign, overrideCallsign in pairs(HOUND.Utils.customFormationCallsignOverrides) do
+                    if callsign:match(vanillaCallsign) then
+                        callsign = callsign:gsub(vanillaCallsign, overrideCallsign)
+                    end
+                end
+            end
             return string.upper(callsign:match( "^%s*(.-)%s*$" ))
+        end
+        if HOUND.Utils.customFormationCallsignOverrides and type(HOUND.Utils.customFormationCallsignOverrides) == 'table' then
+            for vanillaCallsign, overrideCallsign in pairs(HOUND.Utils.customFormationCallsignOverrides) do
+                if callsign:match(vanillaCallsign) then
+                    callsign = callsign:gsub(vanillaCallsign, overrideCallsign)
+                end
+            end
         end
         return string.upper(callsign:match( "^%s*(.-)%s*$" ))
     end

--- a/src/800 - HoundElint.lua
+++ b/src/800 - HoundElint.lua
@@ -1000,6 +1000,16 @@ do
         return retval or false
     end
 
+    -- Override mission editor callsigns for player slots with bespoke callsigns
+    -- @param callsignOverrideTable ex. { Devil = Bengal, Enfield = Victory } -- replaces ME callsigns with bespoke callsigns for TTS. Keys must correspond to mission editor callsigns or they will have no effect
+    -- @returns nil
+    function HoundElint:setCustomFormationCallsignOverrides(callsignOverrideTable)
+        if not type(callsignOverrideTable) == 'table' or type(callsignOverrideTable) == 'nil' then
+            env.error('HOUND.Utils.setCustomFormationCallsignOverrides: first parameter must be a table')
+        end
+        HOUND.Utils.customFormationCallsignOverrides = callsignOverrideTable
+    end
+
     -------------------------------
 
     --- Instance Internal functions


### PR DESCRIPTION
…or TTS. Ex. HoundElint:setCustomFormationCallsignOverrides({ Devil = 'Bengal' }) will speak Devil-1-1 as Bengal-1-1