### PR TITLE
feature/add meta-sectors

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -131,8 +131,8 @@ end
 
 For experienced users and developers:
 
-- **[Main Script Documentation](https://uriba107.github.io/DCS-Hound/web/)** - All available functions
-- **[Developer Documentation](https://uriba107.github.io/DCS-Hound/web/dev/)** - Internal API and architecture
+- **[Main Script Documentation](https://uriba107.github.io/DCS-Hound/)** - All available functions
+- **[Developer Documentation](https://uriba107.github.io/DCS-Hound/dev/)** - Internal API and architecture
 - **[Scripting Ideas](docs/scripting-ideas.md)** - Community examples and creative uses
 
 ---
@@ -195,8 +195,6 @@ HoundBlue:systemOn()
 ---
 
 ## 📋 Version Information
-
-Current documentation is for **Hound ELINT v0.4.x**
 
 - [Breaking Changes Between Versions](docs/breaking-changes.md)
 - [Known Issues](docs/known-issues.md)

--- a/demo_mission/Syria_POC/Hound_Demo_SyADFGCI.lua
+++ b/demo_mission/Syria_POC/Hound_Demo_SyADFGCI.lua
@@ -5,6 +5,23 @@ do
 end
 
 do
+    local getVoice = function(provider)
+        local supertonicVoices = {
+            "F1",
+            "F2",
+            "F3",
+            "F4",
+            "F5",
+            "M1",
+            "M2",
+            "M3",
+            "M4",
+            "M5"
+        } 
+        if provider == "supertonic" then
+            return supertonicVoices[math.random(#supertonicVoices)]
+        end
+    end
     env.info("configuring Hound")
     HOUND.FORCE_MANAGE_MARKERS = true
     Elint_blue = HoundElint:create(coalition.side.BLUE)
@@ -18,71 +35,105 @@ do
 
     -- sectors
     Elint_blue:addSector("Damascus",10)
-    Elint_blue:addSector("South Syria")
-    Elint_blue:addSector("Homs")
-    Elint_blue:addSector("Latakya")
-
-    Elint_blue:addSector("Palmyra")
-    Elint_blue:addSector("Saykal")
-    Elint_blue:addSector("Haleb")
-    Elint_blue:addSector("Tabqua")
-
-    Elint_blue:addSector("Lebanon")
-
-    -- Assets
-    Elint_blue:enableNotifier("default",{freq = "251.000,35.000", modulation = "AM,FM", speed=1})
-    
-    Elint_blue:enableController("Damascus",{freq="306.000", modulation = "AM"})
-    Elint_blue:enableAtis("Damascus",{freq="306.250", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
-    Elint_blue:setCallsign("Damascus","OPTIMUS")
     Elint_blue:setZone("Damascus","Damascus")
 
-    Elint_blue:enableController("South Syria",{freq="306.500", modulation = "AM"})
-    Elint_blue:enableAtis("South Syria",{freq="306.750", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
-    Elint_blue:setCallsign("South Syria","JAZZ")
+    Elint_blue:addSector("South Syria")
     Elint_blue:setZone("South Syria","South Syria")
-
-    Elint_blue:enableController("Homs",{freq="307.000", modulation = "AM"})
-    Elint_blue:setCallsign("Homs","BUMBLEBEE")
+    
+    Elint_blue:addSector("Homs")
     Elint_blue:setZone("Homs","Homs")
-
-    Elint_blue:enableController("Latakya",{freq="307.500", modulation = "AM"})
-    Elint_blue:enableAtis("Latakya",{freq="307.750", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
-    Elint_blue:setCallsign("Latakya","WHEELJACK")
+    
+    Elint_blue:addSector("Latakya")
     Elint_blue:setZone("Latakya","Latakya")
 
-    Elint_blue:enableController("Lebanon",{freq="308.000", modulation = "AM"})
-    Elint_blue:setCallsign("Lebanon","GRIMLOK")
+    Elint_blue:addSector("Palmyra")
+    Elint_blue:setZone("Palmyra","Palmyra")
+    
+    Elint_blue:addSector("Sayqal")
+    Elint_blue:setZone("Sayqal","Sayqal")
+    
+    Elint_blue:addSector("Haleb")
+    Elint_blue:setZone("Haleb","Haleb")
+    
+    Elint_blue:addSector("Tabqa")
+    Elint_blue:setZone("Tabqa","Tabqa")
+
+    Elint_blue:addSector("Lebanon")
     Elint_blue:setZone("Lebanon","Lebanon")
 
-    Elint_blue:enableController("Palmyra",{freq="308.500", modulation = "AM"})
-    Elint_blue:setCallsign("Palmyra","SWOOP")
-    Elint_blue:setZone("Palmyra","Palmyra")
+    -- Meta-sectors
+    local metaSectors = {
+        ["South AO"] = { "Lebanon", "South Syria", "Damascus", "Sayqal" },
+        ["North AO"] = { "Latakya", "Homs", "Haleb" },
+        ["East AO"]  = { "Tabqa", "Palmyra", "Sayqal" },
+    }
+    for metaName, children in pairs(metaSectors) do
+        Elint_blue:addSector(metaName)
+        for _, child in ipairs(children) do
+            Elint_blue:addChildSector(metaName, child)
+        end
+    end
+    Elint_blue:setCallsign("South AO","OPTIMUS")
+    Elint_blue:setCallsign("North AO","JAZZ")
+    Elint_blue:setCallsign("East AO","BUMBLEBEE")
+    Elint_blue:enableController("South AO",{freq="306.000", modulation = "AM", provider="supertonic", voice = getVoice("supertonic"),speed = 1.05})
+    Elint_blue:enableController("North AO",{freq="306.500", modulation = "AM", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.05})
+    Elint_blue:enableController("East AO",{freq="307.000", modulation = "AM", provider="supertonic", voice = getVoice("supertonic"),speed = 1.05})
 
-    Elint_blue:enableController("Saykal",{freq="309.000", modulation = "AM"})
-    Elint_blue:setCallsign("Saykal","RATCHET")
-    Elint_blue:setZone("Saykal","Saykal")
+    -- -- Assets
+    -- Elint_blue:enableNotifier("default",{freq = "251.000,35.000", modulation = "AM,FM", speed=1})
+    
+    -- Elint_blue:enableController("Damascus",{freq="306.000", modulation = "AM"})
+    Elint_blue:enableAtis("Damascus",{freq="306.250", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
+    -- Elint_blue:setCallsign("Damascus","OPTIMUS")
+    -- Elint_blue:setZone("Damascus","Damascus")
 
-    Elint_blue:enableController("Haleb",{freq="309.500", modulation = "AM"})
+    -- Elint_blue:enableController("South Syria",{freq="306.500", modulation = "AM"})
+    Elint_blue:enableAtis("South Syria",{freq="306.750", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
+    -- Elint_blue:setCallsign("South Syria","JAZZ")
+    -- Elint_blue:setZone("South Syria","South Syria")
+
+    -- Elint_blue:enableController("Homs",{freq="307.000", modulation = "AM"})
+    -- Elint_blue:setCallsign("Homs","BUMBLEBEE")
+    -- Elint_blue:setZone("Homs","Homs")
+
+    -- Elint_blue:enableController("Latakya",{freq="307.500", modulation = "AM"})
+    Elint_blue:enableAtis("Latakya",{freq="307.750", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
+    -- Elint_blue:setCallsign("Latakya","WHEELJACK")
+    -- Elint_blue:setZone("Latakya","Latakya")
+
+    -- Elint_blue:enableController("Lebanon",{freq="308.000", modulation = "AM"})
+    -- Elint_blue:setCallsign("Lebanon","GRIMLOK")
+    -- Elint_blue:setZone("Lebanon","Lebanon")
+
+    -- Elint_blue:enableController("Palmyra",{freq="308.500", modulation = "AM"})
+    -- Elint_blue:setCallsign("Palmyra","SWOOP")
+    -- Elint_blue:setZone("Palmyra","Palmyra")
+
+    -- Elint_blue:enableController("Sayqal",{freq="309.000", modulation = "AM"})
+    -- Elint_blue:setCallsign("Sayqal","RATCHET")
+    -- Elint_blue:setZone("Sayqal","Sayqal")
+
+    -- Elint_blue:enableController("Haleb",{freq="309.500", modulation = "AM"})
     Elint_blue:enableAtis("Haleb",{freq="309.750", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
-    Elint_blue:setCallsign("Haleb","SLAG")
-    Elint_blue:setZone("Haleb","Haleb")
+    -- Elint_blue:setCallsign("Haleb","SLAG")
+    -- Elint_blue:setZone("Haleb","Haleb")
 
-    Elint_blue:enableController("Tabqa",{freq="310.000", modulation = "AM"})
-    Elint_blue:setCallsign("Tabqa","IRONHIDE")
-    Elint_blue:setZone("Tabqa","Tabqa")
+    -- Elint_blue:enableController("Tabqa",{freq="310.000", modulation = "AM"})
+    -- Elint_blue:setCallsign("Tabqa","IRONHIDE")
+    -- Elint_blue:setZone("Tabqa","Tabqa")
 
     Elint_blue:enableAtis("Homs",{freq="307.250", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
     Elint_blue:enableAtis("Lebanon",{freq="308.250", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
     Elint_blue:enableAtis("Palmyra",{freq="308.750", modulation = "AM", provider="piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
-    Elint_blue:enableAtis("Saykal",{freq="309.250", modulation = "AM", provider = "piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
+    Elint_blue:enableAtis("Sayqal",{freq="309.250", modulation = "AM", provider = "piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
     Elint_blue:enableAtis("Tabqa",{freq="310.250", modulation = "AM", provider = "piper", voice = "en_US-libritts-high", speaker=math.random(200),speed = 1.15})
     
     
     Elint_blue:enableText("all")
+    Elint_blue:enableAlerts("all")
 
     Elint_blue:setTransmitter("all","Mt_Meron_ELINT")
-    Elint_blue:systemOn()
 
     -- faking Satellite intel, add all enemy IADS EW radars as prebriefed.
     env.info("importing Skynet IADS EWRs")
@@ -96,6 +147,7 @@ do
             Elint_blue:preBriefedContact(ewRadarName)
         end
     end
+    Elint_blue:systemOn()
 
     env.info("Hound - End of config")
 end

--- a/docs/sectors.md
+++ b/docs/sectors.md
@@ -183,11 +183,161 @@ HoundInstance:reportEWR("North", true)
 
 ---
 
+## Meta-Sectors
+
+A meta-sector aggregates multiple child sectors without a zone of its own. Attach a Controller, ATIS, or Notifier to a meta-sector and it will report on contacts from all its children. Child sectors only need a zone — no comms required on them.
+
+```mermaid
+graph TD
+    H["HoundElint Instance"] --> S["Sectors"]
+
+    S --> S1["S1<br/>Zone_S1"]
+    S --> S2["S2<br/>Zone_S2"]
+    S --> S3["S3<br/>Zone_S3"]
+    S --> S4["S4<br/>Zone_S4"]
+    S --> NE["NorthEast<br/>(meta-sector, no zone)"]
+
+    NE -- "child" --> S1
+    NE -- "child" --> S2
+    NE -- "child" --> S3
+    NE -- "child" --> S4
+
+    NE --> C["Controller<br/>Freq: 265.000"]
+    NE --> A["ATIS<br/>Freq: 266.000"]
+    NE --> N["Notifier<br/>Freq: 251.000"]
+
+    style NE fill:#2d6a4f,stroke:#1b4332,color:#d8f3dc
+    style S1 fill:#264653,stroke:#2a9d8f,color:#e9f5db
+    style S2 fill:#264653,stroke:#2a9d8f,color:#e9f5db
+    style S3 fill:#264653,stroke:#2a9d8f,color:#e9f5db
+    style S4 fill:#264653,stroke:#2a9d8f,color:#e9f5db
+```
+
+### How it works
+
+```mermaid
+flowchart LR
+    subgraph Children
+        S1["S1 zone"]
+        S2["S2 zone"]
+    end
+
+    subgraph Membership
+        R1["SA-6 in S1"]
+        R2["SA-10 in S2"]
+        R3["EWR in S1"]
+    end
+
+    subgraph Meta["NorthEast meta-sector"]
+        ATIS["ATIS lists:<br/>SA-6, SA-10, EWR"]
+        Menu["F10 menu:<br/>all 3 sites"]
+        Notify["Notifier:<br/>'SA-6 identified in S1'"]
+    end
+
+    S1 --> R1 & R3
+    S2 --> R2
+    R1 & R2 & R3 --> ATIS & Menu
+    R1 --> Notify
+```
+
+- **Notifications** include the child sector name: _"SA-6 identified in S1"_
+- **ATIS** aggregates all sites from all children (deduplicated)
+- **F10 menus** show all sites from all children
+- **Controller alerts** also include the child sector name
+- The meta-sector itself has **no zone** — it never claims ownership of contacts
+
+### Creating meta-sectors
+
+```lua
+-- Create child sectors (zone only, no comms needed)
+HoundBlue:addSector("Beslan")
+HoundBlue:setZone("Beslan", "Zone_Beslan")
+
+HoundBlue:addSector("Vladikavkaz")
+HoundBlue:setZone("Vladikavkaz", "Zone_Vlad")
+
+-- Create meta-sector and assign children
+HoundBlue:addSector("Northern Front")
+HoundBlue:addChildSector("Northern Front", "Beslan")
+HoundBlue:addChildSector("Northern Front", "Vladikavkaz")
+
+-- Attach comms to the meta-sector
+HoundBlue:enableController("Northern Front", {freq = "265.000", modulation = "AM"})
+HoundBlue:enableAtis("Northern Front", {freq = "266.000", modulation = "AM"})
+HoundBlue:enableNotifier("Northern Front", {freq = "251.000", modulation = "AM"})
+
+-- Remove a child
+HoundBlue:removeChildSector("Northern Front", "Vladikavkaz")
+```
+
+### Overlapping meta-sectors
+
+A child sector can belong to multiple meta-sectors. When a contact is detected in a shared child, all meta-sectors containing that child fire independently.
+
+```mermaid
+graph TD
+    subgraph Grid["3x3 Sector Grid"]
+        S1["S1"] --- S2["S2"] --- S3["S3"]
+        S4["S4"] --- S5["S5"] --- S6["S6"]
+        S7["S7"] --- S8["S8"] --- S9["S9"]
+    end
+
+    NE["NorthEast<br/>S1, S2, S4, S5"]
+    NW["NorthWest<br/>S2, S3, S5, S6"]
+    SE["SouthEast<br/>S4, S5, S7, S8"]
+    SW["SouthWest<br/>S5, S6, S8, S9"]
+
+    NE -. "children" .-> S1 & S2 & S4 & S5
+    NW -. "children" .-> S2 & S3 & S5 & S6
+    SE -. "children" .-> S4 & S5 & S7 & S8
+    SW -. "children" .-> S5 & S6 & S8 & S9
+
+    style NE fill:#2d6a4f,stroke:#1b4332,color:#d8f3dc
+    style NW fill:#2d6a4f,stroke:#1b4332,color:#d8f3dc
+    style SE fill:#2d6a4f,stroke:#1b4332,color:#d8f3dc
+    style SW fill:#2d6a4f,stroke:#1b4332,color:#d8f3dc
+```
+
+In this example, S5 is a child of all four meta-sectors. A contact in S5 triggers notifications on NE, NW, SE, and SW. Each meta-sector deduplicates contacts — a contact in both S2 and S5 appears once in NorthEast's ATIS, not twice.
+
+```lua
+-- Grid setup
+for i = 1, 9 do
+    HoundBlue:addSector("S"..i, { zone = "Zone_S"..i })
+end
+
+-- Overlapping meta-sectors
+HoundBlue:addSector("NorthEast")
+HoundBlue:addChildSector("NorthEast", "S1")
+HoundBlue:addChildSector("NorthEast", "S2")
+HoundBlue:addChildSector("NorthEast", "S4")
+HoundBlue:addChildSector("NorthEast", "S5")
+
+HoundBlue:addSector("NorthWest")
+HoundBlue:addChildSector("NorthWest", "S2")
+HoundBlue:addChildSector("NorthWest", "S3")
+HoundBlue:addChildSector("NorthWest", "S5")
+HoundBlue:addChildSector("NorthWest", "S6")
+
+HoundBlue:enableNotifier("NorthEast", {freq = "251.000", modulation = "AM"})
+HoundBlue:enableNotifier("NorthWest", {freq = "252.000", modulation = "AM"})
+```
+
+### Restrictions
+
+- Reserved sectors (`"default"`, `"all"`) cannot have child sectors
+- A meta-sector should not have its own zone — it purely aggregates children
+- Child sectors only need a zone; no controller/ATIS/notifier required on them
+
+---
+
 ## Troubleshooting
 
 **Radar not in expected sector:** Verify zone name/boundaries with `getZone()`, check weapon range overlap
 
 **Sector menu missing:** Verify sector created, Controller enabled for sector, system activated
+
+**Meta-sector showing no contacts:** Verify child sectors have zones and are created before contacts are detected. Use `getSector()` to retrieve the meta-sector and call `hasChildSector("childName")` on it to verify children are assigned without mutating runtime state.
 
 ---
 

--- a/src/201 - HoundUtils_TTS.lua
+++ b/src/201 - HoundUtils_TTS.lua
@@ -366,4 +366,14 @@ do
         end
         return distance .. " " .. distanceUnit
     end
+
+    --- Get cardinal direction from azimuth
+    -- @local
+    -- @param azimuth in degrees
+    -- @return cardinal direction e.g. "North", "North East"...
+    function HOUND.Utils.TTS.getCardinalDirection(azimuth)
+        local directions = {"North","North East","East","South East","South","South West","West","North West"}
+        local index = l_math.floor(((azimuth + 22.5) % 360) / 45) + 1
+        return directions[index]
+    end
 end

--- a/src/310 - HoundContactEmitter.lua
+++ b/src/310 - HoundContactEmitter.lua
@@ -245,7 +245,7 @@ do
         if self.Kalman then
             return
         end
-        --- this is only needed if not in "kalman mode"
+        -- this is only needed if not in "kalman mode"
         if HOUND.Length(self._dataPoints[datapoint.platformId]) == 0 then
             self._dataPoints[datapoint.platformId] = {}
         end

--- a/src/321 - HoundContactSite_comms.lua
+++ b/src/321 - HoundContactSite_comms.lua
@@ -69,7 +69,7 @@ do
     -- @param[type=string] sectorName Name of primary sector if present function will only return sector data
     -- @return string. compiled message
     function HOUND.Contact.Site:generatePopUpReport(isTTS,sectorName)
-        local msg = self:getName() .. ", " .. self:getDesignation(true) .. ", is active"
+        local msg = self:getDesignation(true) .. ", " .. self:getName() ..  ", is active"
 
         if sectorName then
             msg = msg .. " in " .. sectorName
@@ -94,7 +94,7 @@ do
     -- @param[type=string] sectorName Name of primary sector if present function will only return sector data
     -- @return string. compiled message
     function HOUND.Contact.Site:generateDeathReport(isTTS,sectorName)
-        local msg = self:getName() ..  ", " .. self:getDesignation(true) .. " is down"
+        local msg = self:getDesignation(true) ..  ", " .. self:getName()  .. " is down"
         if sectorName then
             msg = msg .. " in " .. sectorName
         else
@@ -117,7 +117,7 @@ do
     -- @param[type=string] sectorName Name of primary sector if present function will only return sector data
     -- @return string. compiled message
     function HOUND.Contact.Site:generateAsleepReport(isTTS,sectorName)
-        local msg = self:getName() ..  ", " .. self:getDesignation(true) .. " is asleep"
+        local msg =  self:getDesignation(true)..  ", " .. self:getName() .. " is asleep"
         if sectorName then
             msg = msg .. " in " .. sectorName
         else
@@ -167,9 +167,9 @@ do
 
         if sectorName then
             msg = msg .. " in " .. sectorName
-            msg = msg .. ", reclassified as " .. self:getDesignation(true)
+            msg = msg .. ", identified as " .. self:getDesignation(true)
         else
-            msg = msg .. ", reclassified as " .. self:getDesignation(true)
+            msg = msg .. ", identified as " .. self:getDesignation(true)
             local primary = self:getPrimary()
             if primary:hasPos() then
                 local GridPos,BePos

--- a/src/500 - HoundElintWorker.lua
+++ b/src/500 - HoundElintWorker.lua
@@ -395,9 +395,13 @@ do
         local emitterMarker = self.settings:getMarkerType()
         local sites = self.sites
         HOUND.Coroutine.add(function()
+            local count = 0
             for _, site in pairs(sites) do
                 site:updateMarkers(emitterMarker, drawSites)
-                coroutine.yield()
+                count = count + 1
+                if count % 3 == 0 then
+                    coroutine.yield()
+                end
             end
         end, { name = guardName })
     end

--- a/src/550 - HoundSector.lua
+++ b/src/550 - HoundSector.lua
@@ -45,6 +45,7 @@ do
                 root = nil ,noData = nil
             }
         }
+        instance.childSectors = {}
         instance.priority = priority or 10
 
         if settings ~= nil and type(settings) == "table" and HOUND.Length(settings) > 0 then
@@ -227,11 +228,55 @@ do
         end
         if zone then
             self.settings.zone = zone
+            self.zoneCenter = HOUND.Mist.getAvgPoint(zone)
         end
     end
 
     --- Remove Zone settings from sector
     function HOUND.Sector:removeZone() self.settings.zone = nil end
+
+    --- get Sector zone center
+    -- @return DCS point or nil
+    function HOUND.Sector:getCenter()
+        return self.zoneCenter
+    end
+
+    --- Child Sector Functions
+    -- @section ChildSectors
+
+    --- Add a child sector to this meta-sector
+    -- @string sectorName name of child sector
+    function HOUND.Sector:addChildSector(sectorName)
+        if self.name == "default" or self.name == "all" then
+            HOUND.Logger.warn("[Hound] - cannot add child sectors to reserved sector '" .. self.name .. "'")
+            return
+        end
+        self.childSectors[sectorName] = true
+    end
+
+    --- Remove a child sector from this meta-sector
+    -- @string sectorName name of child sector
+    function HOUND.Sector:removeChildSector(sectorName)
+        self.childSectors[sectorName] = nil
+    end
+
+    --- Get child sectors table
+    -- @return table of child sector names (keys) with true values
+    function HOUND.Sector:getChildSectors()
+        return self.childSectors
+    end
+
+    --- Check if sector has child sectors
+    -- @return[type=bool] True if sector has child sectors
+    function HOUND.Sector:hasChildSectors()
+        return next(self.childSectors) ~= nil
+    end
+
+    --- check if sector has specific child sector
+    -- @string sectorName name of child sector
+    function HOUND.Sector:hasChildSector(sectorName)
+        return self.childSectors[sectorName] == true
+    end
 
     --- sets transmitter to sector
     -- @param userTransmitter (String) Name of the Unit that would be transmitting
@@ -487,22 +532,61 @@ do
     --- Contact Functions
     -- @section contacs
 
+    --- Get effective sector names for querying contacts/sites
+    -- @return table list of sector name strings
+    function HOUND.Sector:getEffectiveSectorNames()
+        if next(self.childSectors) then
+            local names = {}
+            for name, _ in pairs(self.childSectors) do
+                table.insert(names, name)
+            end
+            return names
+        end
+        if self:getZone() then
+            return {self.name}
+        end
+        return {"default"}
+    end
+
     --- return a sorted list of all contacts for the sector
     function HOUND.Sector:getContacts()
-        local effectiveSectorName = self.name
-        if not self:getZone() then
-            effectiveSectorName = "default"
+        local sectorNames = self:getEffectiveSectorNames()
+        if #sectorNames == 1 then
+            return self._contacts:listAllContactsByRange(sectorNames[1])
         end
-        return self._contacts:listAllContactsByRange(effectiveSectorName)
+        local seen = {}
+        local merged = {}
+        for _, name in ipairs(sectorNames) do
+            for _, contact in ipairs(self._contacts:listAllContacts(name)) do
+                local id = contact:getId()
+                if not seen[id] then
+                    seen[id] = true
+                    table.insert(merged, contact)
+                end
+            end
+        end
+        table.sort(merged, HoundUtils.Sort.ContactsByRange)
+        return merged
     end
 
     --- count the number of contacts for the sector
     function HOUND.Sector:countContacts()
-        local effectiveSectorName = self.name
-        if not self:getZone() then
-            effectiveSectorName = "default"
+        local sectorNames = self:getEffectiveSectorNames()
+        if #sectorNames == 1 then
+            return self._contacts:countContacts(sectorNames[1])
         end
-        return self._contacts:countContacts(effectiveSectorName)
+        local seen = {}
+        local count = 0
+        for _, name in ipairs(sectorNames) do
+            for _, contact in ipairs(self._contacts:listAllContacts(name)) do
+                local id = contact:getId()
+                if not seen[id] then
+                    seen[id] = true
+                    count = count + 1
+                end
+            end
+        end
+        return count
     end
 
     --- update contact for zone memberships
@@ -513,23 +597,46 @@ do
         self._contacts:getSite(contact):updateSector()
     end
 
-    --- return a sorted list of all contacts for the sector
+    --- return a sorted list of all sites for the sector
     function HOUND.Sector:getSites()
-        local effectiveSectorName = self.name
-        if not self:getZone() then
-            effectiveSectorName = "default"
+        local sectorNames = self:getEffectiveSectorNames()
+        if #sectorNames == 1 then
+            return self._contacts:listAllSitesByRange(sectorNames[1])
         end
-        return self._contacts:listAllSitesByRange(effectiveSectorName)
+        local seen = {}
+        local merged = {}
+        for _, name in ipairs(sectorNames) do
+            for _, site in ipairs(self._contacts:listAllSites(name)) do
+                local id = site:getId()
+                if not seen[id] then
+                    seen[id] = true
+                    table.insert(merged, site)
+                end
+            end
+        end
+        table.sort(merged, HoundUtils.Sort.ContactsByRange)
+        return merged
     end
 
-    --- count the number of contacts for the sector
-    -- @return[type=int] Number of contacts
+    --- count the number of sites for the sector
+    -- @return[type=int] Number of sites
     function HOUND.Sector:countSites()
-        local effectiveSectorName = self.name
-        if not self:getZone() then
-            effectiveSectorName = "default"
+        local sectorNames = self:getEffectiveSectorNames()
+        if #sectorNames == 1 then
+            return self._contacts:countSites(sectorNames[1])
         end
-        return self._contacts:countSites(effectiveSectorName)
+        local seen = {}
+        local count = 0
+        for _, name in ipairs(sectorNames) do
+            for _, site in ipairs(self._contacts:listAllSites(name)) do
+                local id = site:getId()
+                if not seen[id] then
+                    seen[id] = true
+                    count = count + 1
+                end
+            end
+        end
+        return count
     end
 
     -------------- Radio Menu stuff -----------------------------
@@ -649,6 +756,22 @@ do
     --- Message generation
     -- @section messages
 
+    --- Determine if this sector should notify for a contact in the given primary sector
+    -- @string primarySector the contact's primary sector name
+    -- @return bool shouldNotify, string|nil sectorLabel
+    function HOUND.Sector:shouldNotifyFor(primarySector)
+        if self.name == "default" then
+            return true, (primarySector ~= "default") and primarySector or nil
+        end
+        if self.name == primarySector then
+            return true, nil
+        end
+        if self.childSectors[primarySector] then
+            return true, primarySector
+        end
+        return false, nil
+    end
+
     --- Check if sector can notify
     function HOUND.Sector:isNotifiying()
         local controller = self.comms.controller
@@ -663,9 +786,10 @@ do
     -- @return string Announcement
     function HOUND.Sector:getTransmissionAnnounce(index)
         local messages = {
-            "Attention All Aircraft! This is " .. self.callsign .. ". ",
-            "All Aircraft, " .. self.callsign .. ". ",
-            "This is " .. self.callsign .. ". "
+            "All Stations, " .. self.callsign .. ", ",
+            "All Aircraft, " .. self.callsign .. ", ",
+            "All Stations, this is " .. self.callsign .. ", ",
+            "All Aircraft, this is " .. self.callsign .. ", ",
         }
         local retIndex = l_math.random(1,#messages)
         if type(index) == "number" then
@@ -682,12 +806,8 @@ do
         local controller = self.comms.controller
         local notifier = self.comms.notifier
 
-        local contactPrimarySector = contact:getPrimarySector()
-        if self.name ~= "default" and self.name ~= contactPrimarySector then return end
-
-        if self.name == contactPrimarySector then
-            contactPrimarySector = nil
-        end
+        local shouldNotify, sectorLabel = self:shouldNotifyFor(contact:getPrimarySector())
+        if not shouldNotify then return end
 
         local announce = self:getTransmissionAnnounce()
         local enrolledGid = self:getSubscribedGroups()
@@ -695,10 +815,10 @@ do
         local msg = {coalition =  self._hSettings:getCoalition(), priority = 3, gid=enrolledGid}
         msg.contactId = contact:getId()
         -- if (controller and controller:getSettings("enableText")) or (notifier and notifier:getSettings("enableText"))  then
-            msg.txt = contact:generateDeathReport(false,contactPrimarySector)
+            msg.txt = contact:generateDeathReport(false,sectorLabel)
         -- end
         -- if (controller and controller:getSettings("enableTTS")) or (notifier and notifier:getSettings("enableTTS")) then
-            msg.tts = announce .. contact:generateDeathReport(true,contactPrimarySector)
+            msg.tts = announce .. contact:generateDeathReport(true,sectorLabel)
         -- end
         if controller and controller:isEnabled() and controller:getSettings("alerts") then
             controller:addMessageObj(msg)
@@ -716,12 +836,8 @@ do
         local controller = self.comms.controller
         local notifier = self.comms.notifier
 
-        local contactPrimarySector = contact:getPrimarySector()
-        if self.name ~= "default" and self.name ~= contactPrimarySector then return end
-
-        if self.name == contactPrimarySector then
-            contactPrimarySector = nil
-        end
+        local shouldNotify, sectorLabel = self:shouldNotifyFor(contact:getPrimarySector())
+        if not shouldNotify then return end
 
         local announce = self:getTransmissionAnnounce()
         local enrolledGid = self:getSubscribedGroups()
@@ -730,10 +846,10 @@ do
         msg.contactId = contact:getId()
 
         -- if (controller and controller:getSettings("enableText")) or (notifier and notifier:getSettings("enableText"))  then
-            msg.txt = self.callsign .. " Reports " .. contact:generatePopUpReport(false,contactPrimarySector)
+            msg.txt = self.callsign .. " Reports " .. contact:generatePopUpReport(false,sectorLabel)
         -- end
         -- if (controller and controller:getSettings("enableTTS")) or (notifier and notifier:getSettings("enableTTS")) then
-            msg.tts = announce .. contact:generatePopUpReport(true,contactPrimarySector)
+            msg.tts = announce .. contact:generatePopUpReport(true,sectorLabel)
         -- end
 
         if controller and controller:isEnabled() and controller:getSettings("alerts") then
@@ -753,12 +869,8 @@ do
         local controller = self.comms.controller
         local notifier = self.comms.notifier
 
-        local sitePrimarySector = site:getPrimarySector()
-        if self.name ~= "default" and self.name ~= sitePrimarySector then return end
-
-        if self.name == sitePrimarySector then
-            sitePrimarySector = nil
-        end
+        local shouldNotify, sectorLabel = self:shouldNotifyFor(site:getPrimarySector())
+        if not shouldNotify then return end
 
         local announce = self:getTransmissionAnnounce()
         local enrolledGid = self:getSubscribedGroups()
@@ -766,10 +878,10 @@ do
         local msg = {coalition = self._hSettings:getCoalition(), priority = 2 , gid=enrolledGid}
 
         -- if (controller and controller:getSettings("enableText")) or (notifier and notifier:getSettings("enableText"))  then
-            msg.txt = self.callsign .. " Reports " .. site:generateIdentReport(false,sitePrimarySector)
+            msg.txt = self.callsign .. " Reports " .. site:generateIdentReport(false,sectorLabel)
         -- end
         -- if (controller and controller:getSettings("enableTTS")) or (notifier and notifier:getSettings("enableTTS")) then
-            msg.tts = announce .. site:generateIdentReport(true,sitePrimarySector)
+            msg.tts = announce .. site:generateIdentReport(true,sectorLabel)
         -- end
 
         if controller and controller:isEnabled() and controller:getSettings("alerts") then
@@ -788,12 +900,8 @@ do
         local controller = self.comms.controller
         local notifier = self.comms.notifier
 
-        local sitePrimarySector = site:getPrimarySector()
-        if self.name ~= "default" and self.name ~= sitePrimarySector then return end
-
-        if self.name == sitePrimarySector then
-            sitePrimarySector = nil
-        end
+        local shouldNotify, sectorLabel = self:shouldNotifyFor(site:getPrimarySector())
+        if not shouldNotify then return end
 
         local announce = self:getTransmissionAnnounce()
         local enrolledGid = self:getSubscribedGroups()
@@ -801,10 +909,10 @@ do
         local msg = {coalition = self._hSettings:getCoalition(), priority = 2 , gid=enrolledGid}
         msg.contactId = site:getId()
         -- if (controller and controller:getSettings("enableText")) or (notifier and notifier:getSettings("enableText"))  then
-            msg.txt = self.callsign .. " Reports " .. site:generatePopUpReport(false,sitePrimarySector)
+            msg.txt = self.callsign .. " Reports " .. site:generatePopUpReport(false,sectorLabel)
         -- end
         -- if (controller and controller:getSettings("enableTTS")) or (notifier and notifier:getSettings("enableTTS")) then
-            msg.tts = announce .. site:generatePopUpReport(true,sitePrimarySector)
+            msg.tts = announce .. site:generatePopUpReport(true,sectorLabel)
         -- end
         if controller and controller:isEnabled() and controller:getSettings("alerts") then
             controller:addMessageObj(msg)
@@ -824,12 +932,8 @@ do
         local controller = self.comms.controller
         local notifier = self.comms.notifier
 
-        local sitePrimarySector = site:getPrimarySector()
-        if self.name ~= "default" and self.name ~= sitePrimarySector then return end
-
-        if self.name == sitePrimarySector then
-            sitePrimarySector = nil
-        end
+        local shouldNotify, sectorLabel = self:shouldNotifyFor(site:getPrimarySector())
+        if not shouldNotify then return end
 
         local announce = self:getTransmissionAnnounce()
         local enrolledGid = self:getSubscribedGroups()
@@ -838,11 +942,11 @@ do
         msg.contactId = site:getId()
         local body = {}
         if isDead then
-            body.txt = site:generateDeathReport(false,sitePrimarySector)
-            body.tts = site:generateDeathReport(true,sitePrimarySector)
+            body.txt = site:generateDeathReport(false,sectorLabel)
+            body.tts = site:generateDeathReport(true,sectorLabel)
         else
-            body.txt = site:generateAsleepReport(false,sitePrimarySector)
-            body.tts = site:generateAsleepReport(true,sitePrimarySector)
+            body.txt = site:generateAsleepReport(false,sectorLabel)
+            body.tts = site:generateAsleepReport(true,sectorLabel)
         end
         msg.txt = self.callsign .. " Reports " .. body.txt
         msg.tts = announce .. body.tts
@@ -865,20 +969,16 @@ function HOUND.Sector:notifySiteLaunching(site)
         if not self._hSettings:getAlertOnLaunch() or not self:isNotifiying() then return end
         local controller = self.comms.controller
         local notifier = self.comms.notifier
-        local sitePrimarySector = site:getPrimarySector()
-        if self.name ~= "default" and self.name ~= sitePrimarySector then return end
-
-        if self.name == sitePrimarySector then
-            sitePrimarySector = nil
-        end
+        local shouldNotify, sectorLabel = self:shouldNotifyFor(site:getPrimarySector())
+        if not shouldNotify then return end
 
         -- local announce = self:getTransmissionAnnounce()
         local enrolledGid = self:getSubscribedGroups()
 
         local msg = {coalition = self._hSettings:getCoalition(), priority = 1 , gid=enrolledGid}
         msg.contactId = site:getId()
-        msg.txt = site:generateLaunchAlert(false,sitePrimarySector)
-        msg.tts = site:generateLaunchAlert(true,sitePrimarySector)
+        msg.txt = site:generateLaunchAlert(false,sectorLabel)
+        msg.tts = site:generateLaunchAlert(true,sectorLabel)
 
         if controller and controller:isEnabled() and controller:getSettings("alerts") then
             controller:addMessageObj(msg)
@@ -889,72 +989,6 @@ function HOUND.Sector:notifySiteLaunching(site)
         end
 
     end
-
-    -- -- --- Generate Atis message for sector (legacy)
-    -- -- -- @local
-    -- -- -- @param loopData HoundInfomationSystem loop table
-    -- -- -- @param AtisPreferences HoundInfomationSystem settings table
-    -- function HOUND.Sector:generateAtisLegacy(loopData,AtisPreferences)
-    --     local body = ""
-    --     local numberEWR = 0
-    --     local contactCount = self:countContacts()
-    --     if contactCount > 0 then
-    --         local sortedContacts = self:getContacts()
-
-    --         for _, emitter in pairs(sortedContacts) do
-    --             if emitter.pos.p ~= nil then
-    --                 if not emitter.isEWR or
-    --                     (AtisPreferences.reportewr and emitter.isEWR) then
-    --                     body = body ..
-    --                                 emitter:generateTtsBrief(
-    --                                     self._hSettings:getNATO()) .. " "
-    --                 end
-    --                 if (not AtisPreferences.reportewr and emitter.isEWR) then
-    --                     numberEWR = numberEWR + 1
-    --                 end
-    --             end
-    --         end
-    --         if numberEWR > 0 then
-    --             body = body .. numberEWR .. " EWRs are tracked. "
-    --         end
-    --     end
-
-    --     if body == "" then
-    --         if self._hSettings:getNATO() then
-    --             body = ". EMPTY. "
-    --         else
-    --             body = "No threats had been detected "
-    --         end
-    --     end
-
-    --     if loopData.body == body then return end
-    --     loopData.body = body
-
-    --     local reportId
-    --     reportId, loopData.reportIdx =
-    --         HoundUtils.getReportId(loopData.reportIdx)
-
-    --     local header = self.callsign
-    --     local footer = reportId .. "."
-
-    --     if self._hSettings:getNATO() then
-    --         header = header .. " Lowdown "
-    --         footer = "Lowdown " .. footer
-    --     else
-    --         header = header .. " SAM information "
-    --         footer = "you have " .. footer
-    --     end
-    --     header = header .. reportId .. " " ..
-    --                                 HoundUtils.TTS.getTtsTime() .. ". "
-
-    --     local msgObj = {
-    --         coalition = self._hSettings:getCoalition(),
-    --         priority = "loop",
-    --         updateTime = timer.getAbsTime(),
-    --         tts = header .. loopData.body .. footer
-    --     }
-    --     loopData.msg = msgObj
-    -- end
 
     --- Generate Atis message for sector
     -- @local

--- a/src/800 - HoundElint.lua
+++ b/src/800 - HoundElint.lua
@@ -306,20 +306,51 @@ do
         return contacts
     end
 
-    --- dump Intel Brief to csv
-    -- will dump intel summery to CSV in the DCS saved games folder
+    --- dump Intel Brief to CSV or JSON
+    -- will dump intel summary to the DCS saved games folder
     -- requires desanitization of lfs and io modules
     -- @param[opt] filename target filename. (default: hound_contacts_%d.csv)
-    function HoundElint:dumpIntelBrief(filename)
+    -- @param[opt] format target format "csv" or "json" (default: csv)
+    function HoundElint:dumpIntelBrief(filename, format)
         if lfs == nil or io == nil then
-            HOUND.Logger.info("cannot write CSV. please desanitize lfs and io")
+            HOUND.Logger.info("cannot write export file. please desanitize lfs and io")
             return
         end
+        format = format or "csv"
+        if format ~= "csv" and format ~= "json" then
+            HOUND.Logger.warn("invalid format provided for dumpIntelBrief. defaulting to csv")
+            format = "csv"
+        end
         if not filename then
-            filename = string.format("hound_contacts_%d.csv",self:getId())
+            filename = string.format("hound_contacts_%d.%s",self:getId(), format)
+        end
+        if format == "json" then
+            local report = {
+                ReportGenerated = HoundUtils.Text.getTime(),
+                ReportData = {}
+            }
+            for _,site in pairs(self.contacts:listAllSitesByRange()) do
+                local siteItems = site:generateIntelBrief()
+                if #siteItems > 0 then
+                    report.ReportData[site:getId()] = siteItems
+                end
+            end
+            local jsonFile, err = io.open(lfs.writedir() .. filename, "w+")
+            if not jsonFile then
+                HOUND.Logger.warn("Failed to open file for JSON export: " .. tostring(err))
+                return
+            end
+            jsonFile:write(net.lua2json(report))
+            jsonFile:flush()
+            jsonFile:close()
+            return
         end
         local currentGameTime = HoundUtils.Text.getTime()
-        local csvFile = io.open(lfs.writedir() .. filename, "w+")
+        local csvFile, csvErr = io.open(lfs.writedir() .. filename, "w+")
+        if not csvFile then
+            HOUND.Logger.warn("Failed to open file for CSV export: " .. tostring(csvErr))
+            return
+        end
         csvFile:write("SiteId,SiteNatoDesignation,TrackId,RadarType,State,Bullseye,Latitude,Longitude,MGRS,Accuracy,lastSeen,DcsType,DcsUnit,DcsGroup,ReportGenerated\n")
         csvFile:flush()
         for _,site in pairs(self.contacts:listAllSitesByRange()) do

--- a/src/802 - HoundElint_sector_mgmt.lua
+++ b/src/802 - HoundElint_sector_mgmt.lua
@@ -21,6 +21,10 @@ do
             HOUND.Logger.info(sectorName.. " is a reserved sector name")
             return false
         end
+        if type(sectorSettings) == "number" and priority == nil then
+            priority = sectorSettings
+            sectorSettings = nil
+        end
         priority = priority or 50
         if not self.sectors[sectorName] then
             self.sectors[sectorName] = HOUND.Sector.create(self.settings:getId(),sectorName,sectorSettings,priority)
@@ -347,6 +351,24 @@ do
             self.sectors[sectorName]:removeZone()
         end
         self:updateSectorMembership()
+    end
+
+    --- add a child sector to a meta-sector
+    -- @param[type=string] metaSectorName name of the meta-sector
+    -- @param[type=string] childSectorName name of the child sector to add
+    function HoundElint:addChildSector(metaSectorName, childSectorName)
+        if self.sectors[metaSectorName] then
+            self.sectors[metaSectorName]:addChildSector(childSectorName)
+        end
+    end
+
+    --- remove a child sector from a meta-sector
+    -- @param[type=string] metaSectorName name of the meta-sector
+    -- @param[type=string] childSectorName name of the child sector to remove
+    function HoundElint:removeChildSector(metaSectorName, childSectorName)
+        if self.sectors[metaSectorName] then
+            self.sectors[metaSectorName]:removeChildSector(childSectorName)
+        end
     end
 
     --- update sector membership for all contacts

--- a/src/803 - HoundElint_comms.lua
+++ b/src/803 - HoundElint_comms.lua
@@ -311,6 +311,7 @@ do
     -- @return frequncies table for sector's Notifier
     function HoundElint:getNotifierFreq(sectorName)
         sectorName = sectorName or "default"
+        if not self.sectors[sectorName] then return {} end
         return self.sectors[sectorName]:getNotifierFreq() or {}
     end
 

--- a/src/804 - HoundElintEvents.lua
+++ b/src/804 - HoundElintEvents.lua
@@ -42,7 +42,9 @@ do
                 --     sector:notifyEmitterNew(houndEvent.initiator)
                 -- end
                 if houndEvent.id == HOUND.EVENTS.RADAR_DESTROYED then
-                    sector:notifyEmitterDead(houndEvent.initiator)
+                    if houndEvent.initiator.isEWR or HOUND.setContainsValue(houndEvent.initiator.typeAssigned, "Naval") then
+                        sector:notifyEmitterDead(houndEvent.initiator)
+                    end
                 end
                 if houndEvent.id == HOUND.EVENTS.SITE_CREATED then
                     if not houndEvent.initiator.isEWR then

--- a/tools/generate_md_docs.py
+++ b/tools/generate_md_docs.py
@@ -540,7 +540,7 @@ class MarkdownGenerator:
             ('Sector Management', {
                 'addSector', 'removeSector', 'updateSectorSettings', 'listSectors',
                 'getSectors', 'countSectors', 'getSector', 'getZone', 'setZone',
-                'removeZone', 'updateSectorMembership',
+                'removeZone', 'updateSectorMembership', 'addChildSector', 'removeChildSector',
             }),
             ('Controller', {
                 'enableController', 'disableController', 'removeController',
@@ -907,7 +907,7 @@ class MarkdownGenerator:
             "- **Advanced triangulation**: Uses multiple platform bearings for accurate position estimation", 
             "- **Automatic classification**: Identifies radar types and associated weapon systems",
             "- **Multi-platform support**: Works with various ELINT-capable aircraft",
-            "- **Sector management**: Organizes contacts by geographical sectors",
+            "- **Sector management**: Organizes contacts by geographical sectors, supporting meta-sector hierarchies",
             "- **Communication integration**: Provides automated reports via radio and text-to-speech",
             "- **Marker system**: Places visual markers on the F10 map",
             "",
@@ -1134,12 +1134,12 @@ class MarkdownGenerator:
                         "Use HOUND.MARKER.CIRCLE for markers. Wrap in do...end block.",
             },
             {
-                "title": "Multi-Sector Mission with Zones",
-                "desc": "Blue coalition with 4 platforms. Create 2 named sectors: 'North' and "
-                        "'South'. Set geographic zones for each using setZone(). Each sector "
-                        "gets its own Controller and ATIS on different frequencies with male/"
-                        "female voices. Set custom callsigns per sector. Add a global Notifier "
-                        "on guard freq 243.000 AM. Enable text for all sectors. Wrap in do...end.",
+                "title": "Multi-Sector Mission with Meta-Sectors and Zones",
+                "desc": "Blue coalition with 4 platforms. Create two child sectors: 'Beslan' and 'Vladikavkaz', "
+                        "each with its own zone using setZone(). Create a meta-sector 'Northern Front' and "
+                        "add both children to it using addChildSector(). Configure a Controller, ATIS, "
+                        "and Notifier on 'Northern Front' with distinct frequencies. Add a global "
+                        "Notifier on guard freq 243.000 AM. Enable text for all sectors. Wrap in do...end.",
             },
             {
                 "title": "Event Handlers — Custom Mission Logic",
@@ -1406,7 +1406,7 @@ For each task, return ONLY the Lua code in a markdown code block. No explanation
             "| **Platform** | DCS unit that collects radar signals (C-130, tower, etc.) |",
             "| **Contact** | Detected radar emitter with estimated position |",
             "| **Site** | Group of related radars (e.g., SA-6 with TR + SR) |",
-            "| **Sector** | Geographic region with separate comms channels |",
+            "| **Sector** | Geographic region with separate comms channels; can be nested as meta-sectors |",
             "| **Controller** | Interactive F10 radio menu for on-demand intel |",
             "| **ATIS** | Automated periodic threat broadcast |",
             "| **Notifier** | Alert broadcasts (new threats, launches, BDA) |",


### PR DESCRIPTION
  * Feature - Meta-sectors. a sector containing no contacts, just other sectors. will alert on them and controller will show all the contacts aggregated.
  * Feature - Allow json export along side the existing csv export (#75)
  * Bugfix - Extra un-needed radar destruction messages were suppressed. only sites get down message. (#65 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meta-sector support for aggregating child sectors with centralized controller/ATIS.
  * JSON export option for intel briefs.
  * Demo mission updated to showcase meta-sector setup and voices.

* **Improvements**
  * Optimized marker refresh performance.
  * Refined contact/site report wording and cardinal-direction wording support.
  * Radar-destroyed notifications limited to relevant emitter types.

* **Documentation**
  * Added meta-sector docs and examples; updated docs links and version note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->